### PR TITLE
Fix error 'fseeko64 is invalid in C99' when compiling in macOS

### DIFF
--- a/isofs.c
+++ b/isofs.c
@@ -11,10 +11,10 @@
 #include "iso2opl.h"
 
 
-static int isofs_inited = 0;
-static int gIsBigEnd = 0;
 #define ftello64 ftell
 #define fseeko64 fseek
+static int isofs_inited = 0;
+static int gIsBigEnd = 0;
 #define MAX_DIR_CACHE_SECTORS 32
 
 //int g_fh_iso;

--- a/isofs.c
+++ b/isofs.c
@@ -13,7 +13,8 @@
 
 static int isofs_inited = 0;
 static int gIsBigEnd = 0;
-
+#define ftello64 ftell
+#define fseeko64 fseek
 #define MAX_DIR_CACHE_SECTORS 32
 
 //int g_fh_iso;


### PR DESCRIPTION
#### What does this PR do?
Fix error 'implicit declaration of function 'fseeko64' is invalid in C99 ' when compiling in MacOS using gcc compiler.

#### System specification
**Platform**: macOS Mojave 10.14.6 (18G2022)