### PR TITLE
Use of "ftell" and "fseek" means 32 bit file offsets for some platforms.  Use "ftello" and "fseeko" instead.

### DIFF
--- a/isofs.c
+++ b/isofs.c
@@ -11,8 +11,6 @@
 #include "iso2opl.h"
 
 
-#define ftello64 ftell
-#define fseeko64 fseek
 static int isofs_inited = 0;
 static int gIsBigEnd = 0;
 #define MAX_DIR_CACHE_SECTORS 32
@@ -167,7 +165,7 @@ int isofs_ReadISO(s64 offset, u32 nbytes, void *buf)
 
     //lseek64(g_fh_iso, offset, SEEK_SET);
     //r = read(g_fh_iso, buf, nbytes);
-    fseeko64(g_fh_iso, offset, SEEK_SET);
+    fseeko(g_fh_iso, offset, SEEK_SET);
     r = fread(buf, 1, nbytes, g_fh_iso);
 
     /*
@@ -1060,9 +1058,9 @@ s64 isofs_Init(const char *iso_path, int isBigEndian)
 
     //r = lseek64(g_fh_iso, 0, SEEK_END);
     //lseek64(g_fh_iso, 0, SEEK_SET);
-    fseeko64(g_fh_iso, 0, SEEK_END);
-    r = ftello64(g_fh_iso);
-    fseeko64(g_fh_iso, 0, SEEK_SET);
+    fseeko(g_fh_iso, 0, SEEK_END);
+    r = ftello(g_fh_iso);
+    fseeko(g_fh_iso, 0, SEEK_SET);
 
     isofs_inited = 1;
 


### PR DESCRIPTION
Hi, I was looking at PR #1 and kind of gasping...  It is most certainly the wrong fix.

The warning specified was trying to get you to use `ftello(3)`, which is standard and uses `off_t`.  On a lot of platforms `off_t` is 64 bits right off the bat.  Linux needs `_FILE_OFFSET_BITS=64` for that, which it seems this project already uses.  But on my FreeBSD machine it's always 64.

By contrast `ftell(3)` uses `long`, this is probably OK on 64 bit Linux, but on most 32-bit Unix-like OSs, `long` is 32 bits.

`ftello64` by contrast is not standard, and that's what the warning was about -- but "fixing" that warning by potentially shortening the bits of the file offset is not a good call!