### PR TITLE
Makefile fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
 TARGET=iso2opl
-CC = gcc
 
 
 CFLAGS = -std=gnu99 -pedantic -I/usr/include -I/usr/local/include -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
@@ -27,5 +26,5 @@ $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -r $(OBJS) $(TARGET)
+	rm -rf $(OBJS) $(TARGET)
 


### PR DESCRIPTION
1. Add `-f` to `make clean` target: I wrote a script that uses iso2opl, it runs `make clean all` to build it.  But since `-f` does not appear in `rm`, `make clean` fails when it's already clean.

2. I was compiling on FreeBSD, which does not have `gcc` by default, it uses `clang` which is reachable by typing `cc`.  I removed the `CC` definition.  Most `make` implementations will fill in `cc` for this if left unspecified.  I've built this on FreeBSD, Linux and Mac without issues.